### PR TITLE
don't add an integer at the end of a field name

### DIFF
--- a/dma_elementgenerator/DMAElementGeneratorCallbacks.php
+++ b/dma_elementgenerator/DMAElementGeneratorCallbacks.php
@@ -171,8 +171,10 @@ class DMAElementGeneratorCallbacks extends Backend
 						$objField->type='checkboxWizard';
 					}
 
-					//print_r($this->prepareOptions($objField->options));
-					$title = DMA_EG_PREFIX.$objField->title.'_'.$objField->id;
+					// don't add an integer at the end of a field name as Contao javascript (e.g. the file tree reload)
+					// will strip integers at the end as they are used in multi edit mode!
+					// this will kill ajax reload functionality
+					$title = DMA_EG_PREFIX . $objField->title;
 					$replace .= ','.$title;
 					$GLOBALS['TL_DCA'][$strTable]['fields'][$title] = array
 					(


### PR DESCRIPTION
Hey Janosch

I'm going to describe the funny problem in English as a customer of us is going to read the description.
This is really an awful bug and it took me two hours to finally find the issue.

The initial problem was that the file tree did not correctly reload. So e.g. when eval->path was "tl_files/images" it displayed correctly on the first page load. Then I clicked on the tiny icon that opens up the file manager where you can add new files etc. Closing the popup refreshed the content but at the root ("tl_files") instead of "tl_files/images". Really annoying :-)

So I went and analyzed all the funny javascript code and ajax requests and then found that the "path" settings were not applied on ajax requests.

The reason for this is that Contao strips away the integers at the end of a field name upon a request (see here https://github.com/contao/core/blob/master/contao/contao-uncompressed.js#L421).
Contao does that because the edit multiple view adds the id of every entry at the end of a field so it knows what post data belongs to which entry.

To sum up: We're not allowed to use "_<integer>" at the end of a field name as this will break certain functionality of Contao.

I fixed it by simply removing `$objElement->id` but I'm not sure whether it's required for your extension to work properly. So if my proposed solution is not correct and you need the id elsewhere, you have to make sure that it's somewhere **in between**. E.g. for field id 8:

Old and wrong:
- dma_eg_fieldname_8

New and ok:
- dma_eg_8_fieldname
