### PR TITLE
Fixed/Changed Sorting of generated Elements on the Backend-View

### DIFF
--- a/dca/tl_dma_eg.php
+++ b/dca/tl_dma_eg.php
@@ -53,8 +53,8 @@ $GLOBALS['TL_DCA']['tl_dma_eg'] = array
 	(
 		'sorting' => array
 		(
-			'mode'                    => 0,
-			'fields'                  => array('sorting'),
+			'mode'                    => 1,
+			'fields'                  => array('title'),
 			'flag'                    => 1,
 			'panelLayout'             => 'filter;search,limit',
 


### PR DESCRIPTION
Now the Backend-List of generated Elements is sorted alphabetically after the first letter.
