### PR TITLE
use table passed to callback instead of fixed table for images and hyperlinks so they may be used in modules

### DIFF
--- a/src/dma_elementgenerator/DMAElementGeneratorCallbacks.php
+++ b/src/dma_elementgenerator/DMAElementGeneratorCallbacks.php
@@ -544,7 +544,7 @@ class DMAElementGeneratorCallbacks extends Backend
             {
                 $title = DMA_EG_PREFIX . $objField->title . '_' . $objField->id . '--' . $hyperlinkData;
                 $this->paletteReplace .= ',' . $title;
-                $GLOBALS['TL_DCA'][$this->strTable]['fields'][$title] = $GLOBALS['TL_DCA']['tl_content']['fields'][$hyperlinkData];
+                $GLOBALS['TL_DCA'][$this->strTable]['fields'][$title] = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$hyperlinkData];
                 $GLOBALS['TL_DCA'][$this->strTable]['fields'][$title]['load_callback'] = array(array('DMAElementGeneratorCallbacks','load_'.$objField->title . '--' . $hyperlinkData));
                 $GLOBALS['TL_DCA'][$this->strTable]['fields'][$title]['save_callback'] = array(array('DMAElementGeneratorCallbacks','save_'.$objField->title . '--' . $hyperlinkData));
                 $GLOBALS['TL_DCA'][$this->strTable]['fields'][$title]['eval']['alwaysSave'] = true;
@@ -567,7 +567,7 @@ class DMAElementGeneratorCallbacks extends Backend
                 $title = DMA_EG_PREFIX . $objField->title . '_' . $objField->id . '--' . $imageData;
                 $this->paletteReplace .= ',' . $title;
                 
-                $GLOBALS['TL_DCA'][$this->strTable]['fields'][$title] = $GLOBALS['TL_DCA']['tl_content']['fields'][$imageData];
+                $GLOBALS['TL_DCA'][$this->strTable]['fields'][$title] = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$imageData];
                 $GLOBALS['TL_DCA'][$this->strTable]['fields'][$title]['load_callback'] = array(array('DMAElementGeneratorCallbacks','load_'.$objField->title . '--' . $imageData));
                 $GLOBALS['TL_DCA'][$this->strTable]['fields'][$title]['save_callback'] = array(array('DMAElementGeneratorCallbacks','save_'.$objField->title . '--' . $imageData));
                 $GLOBALS['TL_DCA'][$this->strTable]['fields'][$title]['eval']['alwaysSave'] = true;


### PR DESCRIPTION
I went ahead and implemented the fix proposed by Munsio in https://github.com/DMAGmbH/dma_elementgenerator/issues/70#issuecomment-54972144 as I need to be able to set images in DMA-Elements that are used in modules. 