### PR TITLE
Get image_data from tl_content image subpalette(s)

### DIFF
--- a/src/dma_elementgenerator/dca/tl_dma_eg_fields.php
+++ b/src/dma_elementgenerator/dca/tl_dma_eg_fields.php
@@ -436,7 +436,7 @@ $GLOBALS['TL_DCA']['tl_dma_eg_fields'] = array
 			'label' 				=> &$GLOBALS['TL_LANG']['tl_dma_eg_fiels']['image_data'],
 			'exclude' 				=> true,
 			'inputType'             => 'checkbox',
-			'options'               => array('singleSRC', 'alt', 'title', 'size', 'imagemargin', 'imageUrl', 'fullsize', 'caption', 'floating'),
+			'options_callback'      => array('DMA\DMAElementGeneratorCallbacks', 'getImageDataOptions'),
 			'reference'             => &$GLOBALS['TL_LANG']['tl_dma_eg_fields']['image_data_options'],
 			'eval'                  => array('multiple'=>true, 'tl_class'=>'clr'),
             'sql'                   => "blob NULL"

--- a/src/dma_elementgenerator/languages/de/tl_dma_eg_fields.php
+++ b/src/dma_elementgenerator/languages/de/tl_dma_eg_fields.php
@@ -130,17 +130,11 @@ $GLOBALS['TL_LANG']['tl_dma_eg_fields']['renderHiddenData'] = array('Inhalte imm
 	);
 
   $GLOBALS['TL_LANG']['tl_dma_eg_fiels']['image_data'] = array('Bild-Daten','Welche Daten sollen für das Bild abgefragt werden?');
-	$GLOBALS['TL_LANG']['tl_dma_eg_fields']['image_data_options'] = array(
-		'singleSRC' => 'Quelldatei',
-		'alt' => 'Alternativer Text',
-		'title' => 'Titel',
-		'size' => 'Bildbreite und Bildhöhe',
-		'imagemargin' => 'Bildabstand',
-		'imageUrl' => 'Bildlink-Adresse',
-		'fullsize' => 'Großansicht/Neues Fenster',
-		'caption' => 'Bildunterschrift',
-		'floating' => 'Bildausrichtung' 
-	);
+
+  foreach (DMA\DMAElementGeneratorCallbacks::getImageDataOptions() as $option) {
+    $GLOBALS['TL_LANG']['tl_dma_eg_fields']['image_data_options'][$option] = &$GLOBALS['TL_LANG']['tl_content'][$option];
+  }
+  unset($option);
 
 $GLOBALS['TL_LANG']['tl_dma_eg_fields']['optionsType'] = array('Optionen-Art','Optionen können manuell eingegeben werden, oder aus Datanbank generiert werden.');
 $GLOBALS['TL_LANG']['tl_dma_eg_fields']['optDbTable'] = array('Datenbank-Tabelle','Welche Tabelle innerhalb der Datenbank soll für die Generierung der Optionen genutzt werden?');


### PR DESCRIPTION
This way, the available options are always compatible with the Contao core. The motivation for this change is the fact that the field `title` has been renamed to `imageTitle` in Contao 4.4, making the field disappear from ElementGenerator content elements with image fields. Changes like that will be reflected automatically with this change.

Currently, creating a subpalette within the same ElementGenerator field does not seem to be supported, which is why subpalettes of the `useImage` subpalette are merged into the `useImage` subpalette. This affects `overwriteMeta` in Contao 4.4.